### PR TITLE
Use go 1.22 to build postgres arm binaries for aws plugin

### DIFF
--- a/.github/workflows/steampipe-anywhere-aws.yml
+++ b/.github/workflows/steampipe-anywhere-aws.yml
@@ -390,7 +390,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: 1.22
 
       - name: Find stuff and set env
         run: |-
@@ -788,7 +788,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: 1.22
 
       - name: Find stuff and set env
         run: |-


### PR DESCRIPTION
Use go 1.22 to build postgres arm binaries for aws plugin since 1.22 has some code optimization which does not work in 1.21