### PR TITLE
anywhere (generic): bump FDW/export/sqlite pins to SDK v6

### DIFF
--- a/.github/workflows/steampipe-anywhere.yml
+++ b/.github/workflows/steampipe-anywhere.yml
@@ -1,5 +1,31 @@
 name: Steampipe Anywhere Components
 
+# Component pinning
+# -----------------
+# This workflow statically links the plugin into a fixed bundle of
+# steampipe-postgres-fdw, steampipe-export, and steampipe-sqlite. Each of
+# those is pinned below to a specific commit SHA (the trailing comment is
+# the tag or branch the SHA was taken from). The pinning is intentional:
+# every plugin release that ships through Anywhere is built against the
+# exact same FDW/export/sqlite the customer-side runtime expects, so the
+# bundle stays reproducible across re-runs.
+#
+# Coordination requirement: an SDK major-version bump on plugins (e.g.
+# steampipe-plugin-sdk/v5 -> /v6) requires a matching ref-bump PR here.
+# Static linking fails to compile when the plugin's SDK major version
+# diverges from the FDW/export/sqlite pinned below. Merging the SDK bump
+# to plugin develop does NOT flow into this workflow on its own - the
+# pinned SHAs must be updated to commits that carry the new SDK major.
+#
+# This file is the generic reusable workflow used by most plugins (gcp,
+# github, gitlab, slack, etc.). Equivalent comments belong in the
+# cloud-specific variants: steampipe-anywhere-aws.yml,
+# steampipe-anywhere-azure.yml, steampipe-anywhere-azuread.yml,
+# steampipe-anywhere-kubernetes.yml.
+#
+# When bumping: update every occurrence of the SHA (FDW is referenced in
+# many jobs across this file) and the trailing tag/branch comment.
+
 on:
   workflow_dispatch:
     inputs:
@@ -22,7 +48,7 @@ jobs:
         with:
           persist-credentials: false
           repository: "turbot/steampipe-export"
-          ref: 1dfeb24204afc23c4746fd41245402aba811649f # main
+          ref: 676528ebf7121cb6096a744ee7dece6d92638065 # develop (SDK v6)
 
       - name: Set environment variables
         run: |
@@ -81,7 +107,7 @@ jobs:
         with:
           persist-credentials: false
           repository: "turbot/steampipe-postgres-fdw"
-          ref: 217346cf8f9fd199ac319e5317ab84a83c6e151f # v2.2.0
+          ref: 0341161a4c5000fc5b326ae809f5c3e8dce34bea # develop (SDK v6)
 
       - name: If workflow_dispatch, get version from input
         run: |
@@ -170,7 +196,7 @@ jobs:
         with:
           persist-credentials: false
           repository: "turbot/steampipe-postgres-fdw"
-          ref: 217346cf8f9fd199ac319e5317ab84a83c6e151f # v2.2.0
+          ref: 0341161a4c5000fc5b326ae809f5c3e8dce34bea # develop (SDK v6)
 
       - name: If workflow_dispatch, get version from input
         run: |
@@ -277,7 +303,7 @@ jobs:
         with:
           persist-credentials: false
           repository: "turbot/steampipe-postgres-fdw"
-          ref: 217346cf8f9fd199ac319e5317ab84a83c6e151f # v2.2.0
+          ref: 0341161a4c5000fc5b326ae809f5c3e8dce34bea # develop (SDK v6)
 
       - name: If workflow_dispatch, get version from input
         run: |
@@ -373,7 +399,7 @@ jobs:
         with:
           persist-credentials: false
           repository: "turbot/steampipe-postgres-fdw"
-          ref: 217346cf8f9fd199ac319e5317ab84a83c6e151f # v2.2.0
+          ref: 0341161a4c5000fc5b326ae809f5c3e8dce34bea # develop (SDK v6)
 
       - name: If workflow_dispatch, get version from input
         run: |
@@ -448,7 +474,7 @@ jobs:
         with:
           persist-credentials: false
           repository: "turbot/steampipe-postgres-fdw"
-          ref: 217346cf8f9fd199ac319e5317ab84a83c6e151f # v2.2.0
+          ref: 0341161a4c5000fc5b326ae809f5c3e8dce34bea # develop (SDK v6)
 
       - name: If workflow_dispatch, get version from input
         run: |
@@ -537,7 +563,7 @@ jobs:
         with:
           persist-credentials: false
           repository: "turbot/steampipe-postgres-fdw"
-          ref: 217346cf8f9fd199ac319e5317ab84a83c6e151f # v2.2.0
+          ref: 0341161a4c5000fc5b326ae809f5c3e8dce34bea # develop (SDK v6)
 
       - name: If workflow_dispatch, get version from input
         run: |
@@ -651,7 +677,7 @@ jobs:
         with:
           persist-credentials: false
           repository: "turbot/steampipe-postgres-fdw"
-          ref: 217346cf8f9fd199ac319e5317ab84a83c6e151f # v2.2.0
+          ref: 0341161a4c5000fc5b326ae809f5c3e8dce34bea # develop (SDK v6)
 
       - name: If workflow_dispatch, get version from input
         run: |
@@ -752,7 +778,7 @@ jobs:
         with:
           persist-credentials: false
           repository: "turbot/steampipe-postgres-fdw"
-          ref: 217346cf8f9fd199ac319e5317ab84a83c6e151f # v2.2.0
+          ref: 0341161a4c5000fc5b326ae809f5c3e8dce34bea # develop (SDK v6)
 
       - name: If workflow_dispatch, get version from input
         run: |
@@ -826,7 +852,7 @@ jobs:
         with:
           persist-credentials: false
           repository: "turbot/steampipe-sqlite"
-          ref: 98d35058238212af1e73e17db4f95fde43274e8e # main
+          ref: 50543c5743d56d518094280b57c848eaa526eb16 # develop (SDK v6)
 
       - name: If workflow_dispatch, get version from input
         run: |
@@ -894,7 +920,7 @@ jobs:
         with:
           persist-credentials: false
           repository: "turbot/steampipe-sqlite"
-          ref: 98d35058238212af1e73e17db4f95fde43274e8e # main
+          ref: 50543c5743d56d518094280b57c848eaa526eb16 # develop (SDK v6)
 
       - name: If workflow_dispatch, get version from input
         run: |
@@ -944,7 +970,7 @@ jobs:
         with:
           persist-credentials: false
           repository: "turbot/steampipe-sqlite-extension"
-          ref: 98d35058238212af1e73e17db4f95fde43274e8e # main
+          ref: 50543c5743d56d518094280b57c848eaa526eb16 # develop (SDK v6)
 
       - name: If workflow_dispatch, get version from input
         run: |
@@ -1002,7 +1028,7 @@ jobs:
         with:
           persist-credentials: false
           repository: "turbot/steampipe-sqlite-extension"
-          ref: 98d35058238212af1e73e17db4f95fde43274e8e # main
+          ref: 50543c5743d56d518094280b57c848eaa526eb16 # develop (SDK v6)
 
       - name: If workflow_dispatch, get version from input
         run: |
@@ -1054,7 +1080,7 @@ jobs:
         with:
           persist-credentials: false
           repository: "turbot/steampipe-export"
-          ref: f36f51eb4df2eb4addd98aa16cfb311c8918e1f0 # v0.6.1
+          ref: 676528ebf7121cb6096a744ee7dece6d92638065 # develop (SDK v6)
 
       - name: Get latest version tag
         run: |-


### PR DESCRIPTION
## Summary

The generic `steampipe-anywhere.yml` is used by plugins that don't have a cloud-specific variant — gcp, github, gitlab, slack, and others. After the plugin SDK v6 migration shipped to FDW / export / sqlite develop branches today, this workflow was still pinned to v5-era SHAs.

Trigger: `steampipe-plugin-gcp` PR #824 (the GCP rotation fix, analogous to AWS v1.30.3) just merged to main. A `v1.13.x` tag is the next step. Without this pin bump, the GCP tag push would fail Anywhere identically to how AWS v1.30.3 failed before workflows#103.

## Changes

Pin updates — same SHAs as workflows#103 used for `steampipe-anywhere-aws.yml`:

| Component | Old | New |
|---|---|---|
| `steampipe-postgres-fdw` | `217346cf` (v2.2.0) | `0341161a` (develop @ FDW #669 merge) |
| `steampipe-export` (export sites) | `f36f51eb` (v0.6.1) | `676528eb` (develop @ export #96 merge) |
| `steampipe-export` (version-detection site) | `1dfeb242` (main) | `676528eb` (develop @ export #96 merge) |
| `steampipe-sqlite` | `98d35058` (main) | `50543c57` (develop @ sqlite #126 merge) |

Also adds the same top-of-file comment block as workflows#103 explaining the pinning model and the SDK-major-bump coordination requirement.

## Note on `steampipe-sqlite-extension` repo references

This file contains two `repository: "turbot/steampipe-sqlite-extension"` references (the pre-rename name). I left the repo name unchanged and only bumped the SHA — GitHub's repo redirect resolves `steampipe-sqlite-extension` to `steampipe-sqlite`, and the develop SHA `50543c57` is accessible via both names (verified). Cleaning up to the new repo name is reasonable follow-up but out of scope for this rotation-fix unblock.

## Coverage status across Anywhere workflow variants

| Workflow | Status |
|---|---|
| `steampipe-anywhere-aws.yml` | ✓ Bumped + commented in #103 |
| `steampipe-anywhere.yml` (generic, gcp/github/gitlab/slack/etc.) | This PR |
| `steampipe-anywhere-azure.yml` | Still v5-era — bump when azure plugin migrates |
| `steampipe-anywhere-azuread.yml` | Still v5-era — bump when azuread plugin migrates |
| `steampipe-anywhere-kubernetes.yml` | Still v5-era — bump when kubernetes plugin migrates |

The three remaining variants are unchanged because none of those plugins have been migrated to SDK v6 yet. They'll need the same treatment when they migrate.

## Test plan

- [ ] After merge: tag steampipe-plugin-gcp `v1.13.1` and confirm the Anywhere matrix goes green
- [ ] Confirm the gcp GitHub Release object is created with the expected matrix artefacts (`steampipe_postgres_gcp.pg{14,15}.*`, `steampipe_export_gcp.*`, `steampipe_sqlite_gcp.*`)
