### PR TITLE
Update `docker/login-action` version to replace use of Node 16

### DIFF
--- a/.github/workflows/registry-publish-ghcr-azuread-large-runners.yml
+++ b/.github/workflows/registry-publish-ghcr-azuread-large-runners.yml
@@ -188,7 +188,7 @@ jobs:
           oras version
 
       - name: Log in to the Container registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.CR }}
           username: ${{ github.repository_owner }}

--- a/.github/workflows/registry-publish-ghcr-large-runners.yml
+++ b/.github/workflows/registry-publish-ghcr-large-runners.yml
@@ -357,7 +357,7 @@ jobs:
 
       # Login to GHCR
       - name: Log in to the Container registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.CR }}
           username: ${{ github.repository_owner }}

--- a/.github/workflows/registry-publish-ghcr.yml
+++ b/.github/workflows/registry-publish-ghcr.yml
@@ -199,7 +199,7 @@ jobs:
 
       # Login to GHCR
       - name: Log in to the Container registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.CR }}
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
Update action version as Node 16 is being deprecated, the new version uses Node 24.